### PR TITLE
chore: refactoring viewModel to accept injected service

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,7 +16,7 @@ ExportOptions.plist
 *.perspectivev3
 !default.perspectivev3
 xcuserdata/
-
+.nx/
 ## Other
 *.moved-aside
 *.xccheckout

--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -1,0 +1,4 @@
+included:
+    - PostsApp/
+excluded:
+    - Pods

--- a/PostsApp/PostsService.swift
+++ b/PostsApp/PostsService.swift
@@ -9,7 +9,7 @@ import Foundation
 import Alamofire
 
 public enum NetworkError: Error {
-    case NoData
+    case noData
     case error(String)
 }
 
@@ -20,7 +20,7 @@ class PostsService: Service {
     func getPosts(completion: @escaping (Result<PostsResponse, NetworkError>) -> Void) {
         AF.request("https://jsonplaceholder.typicode.com/posts", method: .get).response { response in
             guard let data = response.data else {
-                completion(.failure(.NoData))
+                completion(.failure(.noData))
                 return
             }
             do {

--- a/PostsApp/PostsView.swift
+++ b/PostsApp/PostsView.swift
@@ -34,5 +34,5 @@ struct PostsView: View {
 }
 
 #Preview {
-    PostsView(viewModel: PostsViewModel())
+    PostsView(viewModel: PostsViewModel(service: PostsService()))
 }

--- a/PostsApp/PostsViewModel.swift
+++ b/PostsApp/PostsViewModel.swift
@@ -8,9 +8,13 @@
 import Foundation
 
 public class PostsViewModel: ObservableObject {
-    var postsService: Service = PostsService()
+    var postsService: Service!
     @Published var posts: PostsResponse = []
     @Published var contentState: ContentState = .empty
+
+    init(service: Service) {
+        self.postsService = service
+    }
 
     func getPosts() {
         contentState = .loading

--- a/PostsAppTests/PostsAppTests.swift
+++ b/PostsAppTests/PostsAppTests.swift
@@ -13,8 +13,7 @@ class PostsViewModelTests: XCTestCase {
     var viewModel: PostsViewModel?
 
     override func setUp() {
-        viewModel = PostsViewModel()
-        viewModel?.postsService = MockedPostsService()
+        viewModel = PostsViewModel(service: MockedPostsService())
     }
 
     func testGetPostsMethod() async throws {


### PR DESCRIPTION
refactoring view model to accept Service in its constructor instead of internally created service.